### PR TITLE
Add dev files to `.distignore`

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,8 @@
 .git
 .DS_Store
 .idea
+.distignore
+.gitignore
 phpcs.xml
 phpunit.xml
 composer.json


### PR DESCRIPTION
These `*ignore` files shouldn't be in wp.org `svn` or built `.zip` files