### PR TITLE
Bump Tested Up To to 6.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Contributors: ryankienstra
 Donate link: https://cure.org/donate
 Tags: forms, email, gravity
-Tested up to: 6.5
+Tested up to: 6.9
 Requires at least: 6.4
 Stable tag: 2.0.1
 Requires PHP: 8.0

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
     }
   },
   "scripts": {
-    "lint": "phpcs" ,
-    "lint-fix": "phpcbf" ,
+    "lint": "phpcs",
+    "lint-fix": "phpcbf",
     "test": "phpunit --do-not-cache-result",
     "zip": "./bin/zip.sh"
   }


### PR DESCRIPTION
- [x] Bump Tested Up To to 6.9

CircleCI should deploy this [to wp.org](https://wordpress.org/plugins/adapter-gravity-add-on/) on merging